### PR TITLE
second task

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.7'
+
+services:
+  web:
+    build: .
+    volumes: &web-volumes
+      - &app-volume .:/task_manager:cached
+      - ~/.ssh:/root/.ssh
+      - ~/.bash_history:/root/.bash_history
+      - &bundle-cache-volume bundle_cache:/bundle_cache
+    ports:
+      - 3000:3000
+      - 3001:3001
+      - 3002:3002
+    depends_on:
+      - db
+    environment: &web-environment
+      BUNDLE_PATH: /bundle_cache
+      GEM_HOME: /bundle_cache
+      GEM_PATH: /bundle_cache
+      RAILS_PORT: 3000
+      RUBYOPT: -W:no-deprecated -W:no-experimental
+    command: bundle exec rails s -b '0.0.0.0' -p 3000
+
+  db:
+    image: postgres:11.4
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+
+volumes:
+  bundle_cache:


### PR DESCRIPTION
Настроить запуск проекта через docker-compose

Документация: https://docs.docker.com/compose/

Создать файл docker-compose.yml:

version: '3.7'

services:
  web:
    build: .
    volumes: &web-volumes
      - &app-volume .:/task_manager:cached
      - ~/.ssh:/root/.ssh
      - ~/.bash_history:/root/.bash_history
      - &bundle-cache-volume bundle_cache:/bundle_cache
    ports:
      - 3000:3000
      - 3001:3001
      - 3002:3002
    depends_on:
      - db
    environment: &web-environment
      BUNDLE_PATH: /bundle_cache
      GEM_HOME: /bundle_cache
      GEM_PATH: /bundle_cache
      RAILS_PORT: 3000
      RUBYOPT: -W:no-deprecated -W:no-experimental
    command: bundle exec rails s -b '0.0.0.0' -p 3000

  db:
    image: postgres:11.4
    ports:
      - 5432:5432
    environment:
      POSTGRES_USER: postgres
      POSTGRES_PASSWORD: postgres

volumes:
  bundle_cache:
Сбилдить:

docker-compose build
Мы настроили сервис таким образом, чтобы установленные гемы находились в отдельном volume, в сервисе bundle_cache. Все, что находится в volume, будет персистентно.

Но изначально гемов там нет, поэтому дополнительно выполним команду установки гемов вручную:

docker-compose run --rm web bash -c "bundle install"
В дальнейшем потребуется выполнять команды внутри контейнера. Для этого подойдет команда, описанная в предыдущей строке.

Например, интерактивная bash-сессия внутри контейнера запускается так:

docker-compose run --rm --service-ports web /bin/bash
В завершение нужно создать ветку feature/docker-compose, закоммитить результат туда, запушить, создать пулреквест